### PR TITLE
rust-toolchain update to 1.87 and security advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,8 @@
+[advisories]
+# Ignore specific vulnerability IDs for unmaintained but necessary crates
+ignore = [
+    "RUSTSEC-2024-0388",  # derivative is unmaintained
+    "RUSTSEC-2024-0436",  # paste - no longer maintained
+    "RUSTSEC-2024-0370",  # proc-macro-error is unmaintained
+    "RUSTSEC-2024-0320",  # yaml-rust is unmaintained
+]

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       # Ignored advisories:
-      # - https://rustsec.org/advisories/RUSTSEC-2024-0320 : yaml-rust is unmaintained
-      #   - This is a dependency of the config crate, which does not have a version without yaml-rust.
-      #     See https://github.com/mehcode/config-rs/issues/473
+      # check .cargo/audit.toml for more
       - run: |
-          cargo audit --deny warnings --ignore RUSTSEC-2024-0320
+          cargo audit --deny warnings

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,18 @@ This project implements the Eclipse Foundation Security Policy
 
 * <https://www.eclipse.org/security>
 
+## Known Security Advisories
+
+### Unmaintained Dependencies
+- `derivative`: Version 2.2.0 - Advisory RUSTSEC-2024-0388
+  - Status: Under review for replacement
+- `paste`: Version 1.0.15 - Advisory RUSTSEC-2024-0436
+  - Status: Under review for replacement
+- `proc-macro-error`: Version 1.0.4 - Advisory RUSTSEC-2024-0370
+  - Status: Under review for replacement
+- `yaml-rust`: Version 0.4.5 - Advisory RUSTSEC-2024-0320
+  - Status: Under review for replacement
+
 ## Reporting a Vulnerability
 
 Please report vulnerabilities to the Eclipse Foundation Security Team at

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.72.1"
+channel = "1.87"


### PR DESCRIPTION

rust-toolchain update to 1.87
added .cargo/audit.toml to track security advisories
edited security.md to track security advisories